### PR TITLE
update cargo lock file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "paq"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arrayvec",
  "assert_cmd",


### PR DESCRIPTION
- cargo.lock added to .gitignore preventing publish without update command running