### PR TITLE
add unstable note to installation from repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Installation requires [cargo](https://doc.rust-lang.org/cargo/getting-started/in
 cargo install paq
 ```
 
-#### Install From Repository Clone
+#### Install From Repository Clone (Unstable)
+
+Not recommended due to instability of `main` branch in-between releases.
 
 1. Clone this repository.
 2. Run `cargo install --path .` from repository root.


### PR DESCRIPTION
- added cautionary notes for repo installation due to transient states
- remarks cover merging dependency bumps that **may not** result in a release