### PR TITLE
fix assert_cmd dep warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,13 +66,12 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.17"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
 dependencies = [
  "anstyle",
  "bstr",
- "doc-comment",
  "libc",
  "predicates",
  "predicates-core",
@@ -188,12 +187,6 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rayon = "1.11"
 walkdir = "2.3.2"
 
 [dev-dependencies]
-assert_cmd = "2.0.11"
+assert_cmd = "2.1.1"
 
 [features]
 default = ["test-cleanup"]

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -182,9 +182,14 @@ mod lib {
     }
 }
 
+// added allow deprecated attribute due to cargo_bin notice without a resolution
+#[allow(deprecated)]
 mod bin {
     use crate::utils::TempDir;
-    use assert_cmd::Command;
+    use assert_cmd::{
+        cargo::cargo_bin,
+        Command,
+    };
     use std::path::PathBuf;
 
     #[test]
@@ -198,7 +203,7 @@ mod bin {
         dir.new_file(file_name, file_contents).unwrap();
         let source = dir.path().join(file_name);
 
-        let mut cmd = Command::cargo_bin("paq").unwrap();
+        let mut cmd = Command::new(cargo_bin!("paq"));
         let assert = cmd
             .arg(source.as_os_str().to_str().unwrap())
             .arg("-o")
@@ -228,7 +233,7 @@ mod bin {
         let mut output = PathBuf::from(&source).parent().unwrap().to_path_buf();
         output.push(hash_file_name);
 
-        let mut cmd = Command::cargo_bin("paq").unwrap();
+        let mut cmd = Command::new(cargo_bin!("paq"));
         let assert = cmd
             .arg(source.as_os_str().to_str().unwrap())
             .arg(format!("-o={}", output.as_os_str().to_str().unwrap()))
@@ -256,7 +261,7 @@ mod bin {
         dir.new_file(file_name, file_contents).unwrap();
         let source = dir.path().join(file_name);
 
-        let mut cmd = Command::cargo_bin("paq").unwrap();
+        let mut cmd = Command::new(cargo_bin!("paq"));
         let assert = cmd
             .arg(source.as_os_str().to_str().unwrap())
             .arg("--out")
@@ -286,7 +291,7 @@ mod bin {
         let mut output = PathBuf::from(&source).parent().unwrap().to_path_buf();
         output.push(hash_file_name);
 
-        let mut cmd = Command::cargo_bin("paq").unwrap();
+        let mut cmd = Command::new(cargo_bin!("paq"));
         let assert = cmd
             .arg(source.as_os_str().to_str().unwrap())
             .arg(format!("--out={}", output.as_os_str().to_str().unwrap()))


### PR DESCRIPTION
- ignore notice
- updated assert_cmd cargo_bin usage to macro (accepted future usage)

closes #70 