### PR TITLE
update hash sorting to use rayon parallelization

### DIFF
--- a/benches/functional.rs
+++ b/benches/functional.rs
@@ -109,6 +109,126 @@ mod hash_algorithms {
     }
 }
 
+mod hash_list_sorting {
+    use super::*;
+
+    use rayon::prelude::ParallelSliceMut;
+
+    #[bench]
+    fn bench_blake3_hashes_sequential_sort_1000(b: &mut Bencher) {
+        let mut warmup: Vec<i32> = (0..64).collect();
+        warmup.par_sort_unstable();
+
+        let file_hashes: Vec<[u8; 32]> = (0..1000)
+            .map(|i| {
+                blake3::hash(
+                    format!("test_file_{i}").as_bytes()
+                ).as_bytes().to_owned()
+            })
+            .collect();
+
+        b.iter(move || {
+            let mut file_hashes = file_hashes.clone();
+            file_hashes.sort_unstable();
+        });
+    }
+
+    #[bench]
+    fn bench_blake3_hashes_sequential_sort_2000(b: &mut Bencher) {
+        let mut warmup: Vec<i32> = (0..64).collect();
+        warmup.par_sort_unstable();
+
+        let file_hashes: Vec<[u8; 32]> = (0..2000)
+            .map(|i| {
+                blake3::hash(
+                    format!("test_file_{i}").as_bytes()
+                ).as_bytes().to_owned()
+            })
+            .collect();
+
+        b.iter(move || {
+            let mut file_hashes = file_hashes.clone();
+            file_hashes.sort_unstable();
+        });
+    }
+
+    #[bench]
+    fn bench_blake3_hashes_sequential_sort_5000(b: &mut Bencher) {
+        let mut warmup: Vec<i32> = (0..64).collect();
+        warmup.par_sort_unstable();
+
+        let file_hashes: Vec<[u8; 32]> = (0..5000)
+            .map(|i| {
+                blake3::hash(
+                    format!("test_file_{i}").as_bytes()
+                ).as_bytes().to_owned()
+            })
+            .collect();
+
+        b.iter(move || {
+            let mut file_hashes = file_hashes.clone();
+            file_hashes.sort_unstable();
+        });
+    }
+
+    #[bench]
+    fn bench_blake3_hashes_parallel_sort_1000(b: &mut Bencher) {
+        let mut warmup: Vec<i32> = (0..64).collect();
+        warmup.par_sort_unstable();
+
+        let file_hashes: Vec<[u8; 32]> = (0..1000)
+            .map(|i| {
+                blake3::hash(
+                    format!("test_file_{i}").as_bytes()
+                ).as_bytes().to_owned()
+            })
+            .collect();
+
+        b.iter(move || {
+            let mut file_hashes = file_hashes.clone();
+            file_hashes.par_sort_unstable();
+        });
+    }
+
+    #[bench]
+    fn bench_blake3_hashes_parallel_sort_2000(b: &mut Bencher) {
+        let mut warmup: Vec<i32> = (0..64).collect();
+        warmup.par_sort_unstable();
+
+        let file_hashes: Vec<[u8; 32]> = (0..2000)
+            .map(|i| {
+                blake3::hash(
+                    format!("test_file_{i}").as_bytes()
+                ).as_bytes().to_owned()
+            })
+            .collect();
+
+        b.iter(move || {
+            let mut file_hashes = file_hashes.clone();
+            file_hashes.par_sort_unstable();
+        });
+    }
+
+    #[bench]
+    fn bench_blake3_hashes_parallel_sort_5000(b: &mut Bencher) {
+        let mut warmup: Vec<i32> = (0..64).collect();
+        warmup.par_sort_unstable();
+
+        let file_hashes: Vec<[u8; 32]> = (0..5000)
+            .map(|i| {
+                blake3::hash(
+                    format!("test_file_{i}").as_bytes()
+                ).as_bytes().to_owned()
+            })
+            .collect();
+
+        b.iter(move || {
+            let mut file_hashes = file_hashes.clone();
+            file_hashes.par_sort_unstable();
+        });
+    }
+}
+
 mod file_size {
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,8 @@ fn hash_paths(root: &Path, paths: Vec<PathBuf>) -> Vec<[u8; 32]> {
         .into_par_iter()
         .map(|path| hash_path(root, path))
         .collect();
-    hashes.sort_unstable();
+    // parallel sort using default rayon MAX_SEQUENTIAL threshold (2k items)
+    hashes.par_sort_unstable();
     hashes
 }
 


### PR DESCRIPTION
- uses standard rayon `par_sort_unstable` which currently has sequential sort under 2000 items
- added benchmarks for comparison and possible future optimization

closes #88 