### PR TITLE
add erorr handling to `paq` cli exec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "paq"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +458,7 @@ dependencies = [
 name = "paq"
 version = "1.4.1"
 dependencies = [
+ "anyhow",
  "arrayvec",
  "assert_cmd",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paq"
-version = "1.4.1"
+version = "1.5.0"
 authors = ["Gregory Langlais <_@gregorylanglais.com>"]
 edition = "2021"
 description = "Hash file or directory recursively."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ harness = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.104"
 arrayvec = "0.7.6"
 blake3 = "1.8.5"
 clap = { version = "4.6.1", features = ["cargo", "unstable-styles"] }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -5,11 +5,12 @@
 //! cargo run -- -h
 //! ```
 
+use anyhow::Context;
 use clap::{
     builder::TypedValueParser, crate_description, crate_name, crate_version, error::ContextKind,
     error::ContextValue, error::ErrorKind, Arg, ArgAction, Command,
 };
-use paq::hash_source;
+use paq::try_hash_source;
 use std::{
     fs::File,
     io::{
@@ -58,20 +59,22 @@ impl TypedValueParser for PathBufferValueParser {
     }
 }
 
-fn derive_output_filepath(source: &Path) -> PathBuf {
-    let source_canonical = source.canonicalize().unwrap();
-    let source_filename = source_canonical.file_name().unwrap().to_str().unwrap();
-    let mut path_buffer = PathBuf::from(source_canonical.parent().unwrap());
-    path_buffer.push(format!("{source_filename}.paq"));
-    path_buffer
+fn derive_output_filepath(source: &Path) -> Result<PathBuf, Error> {
+    let source_canonical = source.canonicalize()?;
+    let mut source_filename = source_canonical
+        .file_name()
+        .ok_or_else(|| Error::other("source path has no file name"))?
+        .to_os_string();
+    source_filename.push(".paq");
+    Ok(source_canonical.with_file_name(source_filename))
 }
 
-fn write_hashfile(filepath: &PathBuf, hash: &str) -> Result<(), Error> {
-    let mut file = File::create(filepath).unwrap();
+fn write_hashfile(filepath: &Path, hash: &str) -> Result<(), Error> {
+    let mut file = File::create(filepath)?;
     file.write_all(format!("\"{hash}\"").as_bytes())
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let output_default = "<src>.paq";
     let matches = Command::new(crate_name!())
         .version(crate_version!())
@@ -112,15 +115,22 @@ fn main() {
     let source = matches.get_one::<PathBuf>("src").unwrap();
     let ignore_hidden = matches.get_flag("ignore-hidden");
     let output: Option<&PathBuf> = matches.get_one::<PathBuf>("filepath");
-    let hash = hash_source(source, ignore_hidden);
+    let hash = try_hash_source(source, ignore_hidden)
+        .with_context(|| format!("failed to hash `{}`", source.display()))?;
 
     if let Some(filepath) = output {
-        let output_filepath = match filepath.to_str().unwrap() {
-            s if s == output_default => derive_output_filepath(source),
-            _ => filepath.to_path_buf(),
+        let output_filepath = if filepath.as_path() == Path::new(output_default) {
+            derive_output_filepath(source).with_context(|| {
+                format!("failed to derive output path for `{}`", source.display())
+            })?
+        } else {
+            filepath.to_path_buf()
         };
-        write_hashfile(&output_filepath, hash.as_str()).unwrap();
+        write_hashfile(&output_filepath, hash.as_str()).with_context(|| {
+            format!("failed to write hash to `{}`", output_filepath.display())
+        })?;
     }
 
     println!("{hash}");
+    Ok(())
 }

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -221,6 +221,87 @@ mod bin {
     use std::path::PathBuf;
 
     #[test]
+    fn it_outputs_directory_hash_using_default_source() {
+        let expectation = "82878ed8a480ee41775636820e05a934ca5c747223ca64306658ee5982e6c227";
+
+        let dir = TempDir::new("it_outputs_directory_hash_using_default_source").unwrap();
+
+        let mut cmd = Command::new(cargo_bin!("paq"));
+        let assert = cmd
+            .current_dir(dir.path())
+            .assert();
+        assert
+            .code(0)
+            .stdout(format!("{expectation}\n"))
+            .success();
+    }
+
+    #[test]
+    fn it_outputs_file_hash_without_output() {
+        let expectation = "48ec422c86fd2aa1ac182f832c10cf6cb07e4b89d88b83a7794bd8773460072c";
+
+        let file_name = "alpha";
+        let file_contents = "alpha-body".as_bytes();
+        let hash_file_name = "alpha.paq";
+        let dir = TempDir::new("it_outputs_file_hash_without_output").unwrap();
+        dir.new_file(file_name, file_contents).unwrap();
+        let source = dir.path().join(file_name);
+
+        let mut cmd = Command::new(cargo_bin!("paq"));
+        let assert = cmd
+            .arg(source.as_os_str().to_str().unwrap())
+            .assert();
+        assert
+            .code(0)
+            .stdout(format!("{expectation}\n"))
+            .success();
+
+        assert!(!dir.path().join(hash_file_name).exists());
+    }
+
+    #[test]
+    fn it_ignores_hidden_files_using_short_arg() {
+        let expectation = "82878ed8a480ee41775636820e05a934ca5c747223ca64306658ee5982e6c227";
+
+        let file_name = ".ignored";
+        let file_contents = ".ignored-body".as_bytes();
+        let dir = TempDir::new("it_ignores_hidden_files_using_short_arg").unwrap();
+        dir.new_file(file_name, file_contents).unwrap();
+        let source = dir.path().canonicalize().unwrap();
+
+        let mut cmd = Command::new(cargo_bin!("paq"));
+        let assert = cmd
+            .arg(source.as_os_str().to_str().unwrap())
+            .arg("-i")
+            .assert();
+        assert
+            .code(0)
+            .stdout(format!("{expectation}\n"))
+            .success();
+    }
+
+    #[test]
+    fn it_ignores_hidden_files_using_long_arg() {
+        let expectation = "82878ed8a480ee41775636820e05a934ca5c747223ca64306658ee5982e6c227";
+
+        let file_name = ".ignored";
+        let file_contents = ".ignored-body".as_bytes();
+        let dir = TempDir::new("it_ignores_hidden_files_using_long_arg").unwrap();
+        dir.new_file(file_name, file_contents).unwrap();
+        let source = dir.path().canonicalize().unwrap();
+
+        let mut cmd = Command::new(cargo_bin!("paq"));
+        let assert = cmd
+            .arg(source.as_os_str().to_str().unwrap())
+            .arg("--ignore-hidden")
+            .assert();
+        assert
+            .code(0)
+            .stdout(format!("{expectation}\n"))
+            .success();
+    }
+
+    #[test]
     fn it_outputs_file_hash_using_default_short_arg() {
         let expectation = "48ec422c86fd2aa1ac182f832c10cf6cb07e4b89d88b83a7794bd8773460072c";
 
@@ -230,6 +311,33 @@ mod bin {
         let dir = TempDir::new("it_outputs_file_hash_using_default_short_arg").unwrap();
         dir.new_file(file_name, file_contents).unwrap();
         let source = dir.path().join(file_name);
+
+        let mut cmd = Command::new(cargo_bin!("paq"));
+        let assert = cmd
+            .arg(source.as_os_str().to_str().unwrap())
+            .arg("-o")
+            .assert();
+        assert
+            .code(0)
+            .stdout(format!("{expectation}\n"))
+            .success();
+
+        let file_hash = dir.read_file(hash_file_name).unwrap();
+        assert_eq!(
+            file_hash.as_slice(),
+            format!("\"{expectation}\"").as_bytes()
+        );
+    }
+
+    #[test]
+    fn it_outputs_directory_hash_using_default_short_arg() {
+        let expectation = "82878ed8a480ee41775636820e05a934ca5c747223ca64306658ee5982e6c227";
+
+        let source_name = "source";
+        let hash_file_name = "source.paq";
+        let dir = TempDir::new("it_outputs_directory_hash_using_default_short_arg").unwrap();
+        let source = dir.path().join(source_name);
+        std::fs::create_dir(&source).unwrap();
 
         let mut cmd = Command::new(cargo_bin!("paq"));
         let assert = cmd
@@ -334,5 +442,59 @@ mod bin {
             file_hash.as_slice(),
             format!("\"{expectation}\"").as_bytes()
         );
+    }
+
+    #[test]
+    fn it_returns_error_for_missing_output_directory() {
+        let file_name = "alpha";
+        let file_contents = "alpha-body".as_bytes();
+        let dir = TempDir::new("it_returns_error_for_missing_output_directory").unwrap();
+        dir.new_file(file_name, file_contents).unwrap();
+        let source = dir.path().join(file_name);
+        let output = dir.path().join("missing").join("alpha.paq");
+
+        let mut cmd = Command::new(cargo_bin!("paq"));
+        let assert = cmd
+            .arg(source.as_os_str().to_str().unwrap())
+            .arg(format!("--out={}", output.as_os_str().to_str().unwrap()))
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        assert!(stderr.contains("failed to write hash to"));
+    }
+
+    #[test]
+    fn it_rejects_missing_source_arg() {
+        let dir = TempDir::new("it_rejects_missing_source_arg").unwrap();
+        let source = dir.path().join("missing");
+
+        let mut cmd = Command::new(cargo_bin!("paq"));
+        let assert = cmd
+            .arg(source.as_os_str().to_str().unwrap())
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        assert!(stderr.contains("valid file or directory path"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn it_reports_error_for_invalid_utf8_path() {
+        use std::{
+            ffi::OsString,
+            os::unix::ffi::OsStringExt,
+        };
+
+        let dir = TempDir::new("it_reports_error_for_invalid_utf8_path").unwrap();
+        let file_name = OsString::from_vec(vec![0xff]);
+        std::fs::write(dir.path().join(file_name), b"").unwrap();
+
+        let mut cmd = Command::new(cargo_bin!("paq"));
+        let assert = cmd
+            .arg(dir.path().as_os_str().to_str().unwrap())
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        assert!(stderr.contains("failed to hash"));
     }
 }


### PR DESCRIPTION
- adds anyhow dep to crate w/use restricted to cli
- updates `paq` cli executable to return error types from main (errs to stderr w/exit code 1)
- adds functional tests for uncovered bin functions

close #151 